### PR TITLE
Fixed return type for stats_rand_gen_t()

### DIFF
--- a/stats.stub.php
+++ b/stats.stub.php
@@ -43,7 +43,7 @@ function stats_rand_ibinomial(int $n, float $pp): int|false {}
 function stats_rand_ibinomial_negative(int $n, float $p): int|false {}
 function stats_rand_gen_ipoisson(float $mu): int|false {}
 function stats_rand_gen_noncentral_t(float $df, float $xnonc): float|false {}
-function stats_rand_gen_t(float $df): array|false {}
+function stats_rand_gen_t(float $df): float|false {}
 function stats_dens_normal(float $x, float $ave, float $stdev): float|false {}
 function stats_dens_cauchy(float $x, float $ave, float $stdev): float|false {}
 function stats_dens_laplace(float $x, float $ave, float $stdev): float|false {}

--- a/stats_arginfo.h
+++ b/stats_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: e6cfe06b9c3e187348f16fd6a34bb7eafc5042d9 */
+ * Stub hash: 2dca8eb298b57b9da45d9270b4bc97de0faad1aa */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_stats_cdf_t, 0, 3, MAY_BE_DOUBLE|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, par1, IS_DOUBLE, 0)
@@ -137,9 +137,7 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_stats_rand_gen_noncentral_t arginfo_stats_rand_gen_noncentral_chisquare
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_stats_rand_gen_t, 0, 1, MAY_BE_ARRAY|MAY_BE_FALSE)
-	ZEND_ARG_TYPE_INFO(0, df, IS_DOUBLE, 0)
-ZEND_END_ARG_INFO()
+#define arginfo_stats_rand_gen_t arginfo_stats_rand_gen_chisquare
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_stats_dens_normal, 0, 3, MAY_BE_DOUBLE|MAY_BE_FALSE)
 	ZEND_ARG_TYPE_INFO(0, x, IS_DOUBLE, 0)


### PR DESCRIPTION
The code, [the manual](https://www.php.net/manual/en/function.stats-rand-gen-t.php) and the doc-comment show that the function returns `float|false`, it looks like there is a misprint in the stub-file.

The problem appeared when I run tests with PHP built with `--enable-debug --enable-debug-assertions`