### PR TITLE
Fixes to get it building properly

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -26,10 +26,10 @@ http://pear.php.net/dtd/package-2.0.xsd">
   <email>uchiyama@php.net</email>
   <active>yes</active>
  </lead>
- <date>2016-06-02</date>
+ <date>2023-06-20</date>
  <version>
-  <release>2.0.3-dev</release>
-  <api>2.0.3</api>
+  <release>2.1.0</release>
+  <api>2.1.0</api>
  </version>
  <stability>
   <release>stable</release>
@@ -151,6 +151,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
    <file name="randlib.c" role="src" />
    <file name="randlib.h" role="src" />
    <file name="php_stats.c" role="src" />
+   <file name="stats_arginfo.h" role="src" />
    <file name="TODO" role="doc" />
    <file name="LICENSE" role="doc" />
   </dir> <!-- / -->

--- a/php_stats.c
+++ b/php_stats.c
@@ -54,7 +54,7 @@
     ZEND_ARG_TYPE_INFO(pass_by_ref, name, type_hint, allow_null)
 #endif
 
-#include "stats_arginfo.h"
+#include <stats_arginfo.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>


### PR DESCRIPTION
Had problems building with it erroring out on ```2.0.3-dev``` once this was changed it then went further but complained about missing file ```stats_arginfo.h```.  Some other minor corrections, but at least builds fine now without errors.

Built on PHP 8.1 and 8.2 successfully so far.