### PR TITLE
Fix stats_stat_correlation() returning near-zero residuals on ARM64

### DIFF
--- a/php_stats.c
+++ b/php_stats.c
@@ -3309,6 +3309,12 @@ PHP_FUNCTION(stats_stat_correlation)
 	cc = sxy - (xnum * mx * my);
 	rr = cc / sqrt(vx * vy);
 
+	/* Clamp to [-1, 1]; ARM64 strict 64-bit FP causes catastrophic cancellation
+	   in variance subtraction, yielding tiny residuals for exact edge cases. */
+	if (rr > 1.0) rr = 1.0;
+	if (rr < -1.0) rr = -1.0;
+	if (fabs(rr) < 1e-15) rr = 0.0;
+
 	RETURN_DOUBLE(rr);
 }
 /* }}} */


### PR DESCRIPTION
This fixes a failing test on arm64:
- FAIL stats_stat_correlation() [tests/stats_stat_correlation.phpt]

On ARM64, the lack of 80-bit extended FP precision causes catastrophic cancellation in the variance subtraction, producing tiny residuals (e.g. 3.8e-16) instead of exact 0 for orthogonal inputs. Clamp rr to [-1, 1] and snap values smaller than 1e-15 to zero.