### PR TITLE
Fix php85 bucket compare func

### DIFF
--- a/php_stats.c
+++ b/php_stats.c
@@ -111,8 +111,16 @@ PHP_MINFO_FUNCTION(stats)
  *
  * This is not correct any more, depends on what compare_func is set to.
  */
+#if PHP_VERSION_ID >= 80500
 static int stats_array_data_compare(Bucket *f, Bucket *s)
+#else
+static int stats_array_data_compare(const void *a, const void *b)
+#endif
 {
+#if PHP_VERSION_ID < 80500
+	Bucket *f = (Bucket *) a;
+	Bucket *s = (Bucket *) b;
+#endif
 	int result;
 	zval first;
 	zval second;

--- a/php_stats.c
+++ b/php_stats.c
@@ -111,16 +111,11 @@ PHP_MINFO_FUNCTION(stats)
  *
  * This is not correct any more, depends on what compare_func is set to.
  */
-static int stats_array_data_compare(const void *a, const void *b)
+static int stats_array_data_compare(Bucket *f, Bucket *s)
 {
-	Bucket *f;
-	Bucket *s;
 	int result;
 	zval first;
 	zval second;
-
-	f = (Bucket *) a;
-	s = (Bucket *) b;
 
 	first = f->val;
 	second = s->val;


### PR DESCRIPTION
Update the `stats_array_data_compare` function in `php_stats.c` to support PHP 8.5 while maintaining compatibility < 8.5. 